### PR TITLE
`.devcontainer` 更新

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,8 @@
     },
     "workspaceFolder": "/workspace",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
-    "postCreateCommand": "sudo chown node node_modules",
+    // NOTE: deterministic-zip のインストール（第10章で使用）
+    "postCreateCommand": "curl -sS https://raw.githubusercontent.com/timo-reymann/deterministic-zip/main/installer | bash",
     "remoteUser": "node",
     "customizations": {
         "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,9 +8,6 @@
     },
     "workspaceFolder": "/workspace",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
-    "mounts": [
-      "source=node_modules,target=${containerWorkspaceFolder}/node_modules"
-    ],
     "postCreateCommand": "sudo chown node node_modules",
     "remoteUser": "node",
     "customizations": {


### PR DESCRIPTION
- 章ごとにAWS CDKプロジェクトをセットアップする都合上、ルート直下の `node_modules` が不要のため削除
- 第10章で使用するツール `deterministic-zip` のインストールコマンドを `postCreateCommand` に追加
